### PR TITLE
Add RMA requests module

### DIFF
--- a/src/atldld/cli.py
+++ b/src/atldld/cli.py
@@ -31,6 +31,9 @@ def root():
     """Run the command line interface for Atlas-Download-Tools."""
 
 
+# ============================= Info subcommand ================================
+
+
 @click.group(help="Informational subcommands.")
 def info():
     """Run informational subcommands."""
@@ -56,6 +59,77 @@ def cache_folder():
 root.add_command(info)
 info.add_command(version)
 info.add_command(cache_folder)
+
+
+# ============================= Dataset subcommand =============================
+
+
+@click.group(help="Commands related to atlas datasets")
+def dataset():
+    """Run dataset subcommands."""
+
+
+@click.command("info", help="Get information for a given dataset ID")
+@click.argument("dataset_id", type=int)
+def dataset_info(dataset_id):
+    """Get information for a given dataset ID."""
+    import textwrap
+
+    import atldld.dataset
+    from atldld import requests
+
+    # Send request
+    rma_parameters = requests.RMAParameters(
+        "SectionDataSet",
+        criteria={"id": dataset_id},
+        include=("genes", "section_images"),
+    )
+    try:
+        msg = requests.rma_all(rma_parameters)
+    except requests.RMAError as exc:
+        click.secho(
+            f"An error occurred while querying the AIBS servers: {str(exc)}",
+            fg="red",
+        )
+
+    # Check response
+    if len(msg) == 0:
+        click.secho(f"Dataset with ID {dataset_id} does not exist", fg="red")
+        raise click.Abort
+    elif len(msg) > 1:
+        click.secho("Something went wrong: got more than one dataset", fg="red")
+        raise click.Abort
+
+    # Print response
+    meta = msg[0]
+    section_images = meta.pop("section_images")
+    r_str = meta["red_channel"] or "-"
+    g_str = meta["green_channel"] or "-"
+    b_str = meta["blue_channel"] or "-"
+    plane_of_section = atldld.dataset.PlaneOfSection(meta["plane_of_section_id"])
+    reference_space = atldld.dataset.ReferenceSpace(meta["reference_space_id"])
+    output = f"""
+    ID                       : {meta["id"]}
+    Sphinx ID                : {meta["sphinx_id"]}
+    Specimen ID              : {meta["specimen_id"]}
+    Name                     : {meta["name"] or "-"}
+    Failed                   : {"Yes" if meta["failed"] else "No"}
+    Expression               : {"Yes" if meta["expression"] else "No"}
+    Gene(s)                  : {", ".join(gene["acronym"] for gene in meta["genes"])}
+    RGB channels             : {r_str} / {g_str} / {b_str}
+    Section thickness        : {meta["section_thickness"]}µm
+    Plane of section         : {plane_of_section}
+    Number of section images : {len(section_images)}
+    Reference space          : {reference_space.value} ({reference_space})
+    """
+    click.secho(textwrap.dedent(output).strip(), fg="green")
+
+
+root.add_command(dataset)
+dataset.add_command(dataset_info)
+
+
+# ============================= Entry point=====================================
 
 if __name__ == "__main__":
     root()

--- a/src/atldld/dataset.py
+++ b/src/atldld/dataset.py
@@ -1,3 +1,19 @@
+# The package atldld is a tool to download atlas data.
+#
+# Copyright (C) 2021 EPFL/Blue Brain Project
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import enum
 
 

--- a/src/atldld/dataset.py
+++ b/src/atldld/dataset.py
@@ -1,0 +1,27 @@
+import enum
+
+
+class PlaneOfSection(enum.Enum):
+    CORONAL = 1
+    SAGITTAL = 2
+
+    def __str__(self):
+        if self == self.CORONAL:
+            return "coronal"
+        elif self == self.SAGITTAL:
+            return "sagittal"
+        else:
+            return f"unknown ({self})"
+
+
+class ReferenceSpace(enum.Enum):
+    P56 = 9
+    P56_LR_FLIPPED = 10
+
+    def __str__(self):
+        if self == self.P56:
+            return "P56 Brain"
+        elif self == self.P56_LR_FLIPPED:
+            return "P56 Brain, L/R Flipped"
+        else:
+            return f"unknown ({self})"

--- a/src/atldld/dataset.py
+++ b/src/atldld/dataset.py
@@ -6,22 +6,17 @@ class PlaneOfSection(enum.Enum):
     SAGITTAL = 2
 
     def __str__(self):
-        if self == self.CORONAL:
-            return "coronal"
-        elif self == self.SAGITTAL:
-            return "sagittal"
-        else:
-            return f"unknown ({self})"
+        return self.name.lower()
 
 
 class ReferenceSpace(enum.Enum):
     P56 = 9
     P56_LR_FLIPPED = 10
 
+    __names__ = {
+        P56: "P56 Brain",
+        P56_LR_FLIPPED: "P56 Brain, L/R Flipped",
+    }
+
     def __str__(self):
-        if self == self.P56:
-            return "P56 Brain"
-        elif self == self.P56_LR_FLIPPED:
-            return "P56 Brain, L/R Flipped"
-        else:
-            return f"unknown ({self})"
+        return self.__names__[self.value]

--- a/src/atldld/requests.py
+++ b/src/atldld/requests.py
@@ -42,11 +42,12 @@ class RMAParameters:
             flags.extend(self.include)
 
         # Options
-        flags.append("rma::options")
-        if self.start_row is not None:
-            flags.append(f"[start_row$eq{self.start_row}]")
-        if self.num_rows is not None:
-            flags.append(f"[num_rows$eq{self.num_rows}]")
+        if self.start_row is not None and self.num_rows is not None:
+            flags.append("rma::options")
+            if self.start_row is not None:
+                flags.append(f"[start_row$eq{self.start_row}]")
+            if self.num_rows is not None:
+                flags.append(f"[num_rows$eq{self.num_rows}]")
 
         return f'criteria={",".join(flags)}'
 

--- a/src/atldld/requests.py
+++ b/src/atldld/requests.py
@@ -42,12 +42,13 @@ class RMAParameters:
             flags.extend(self.include)
 
         # Options
-        if self.start_row is not None and self.num_rows is not None:
-            flags.append("rma::options")
+        if self.start_row is not None or self.num_rows is not None:
+            flag = "rma::options"
             if self.start_row is not None:
-                flags.append(f"[start_row$eq{self.start_row}]")
+                flag += f"[start_row$eq{self.start_row}]"
             if self.num_rows is not None:
-                flags.append(f"[num_rows$eq{self.num_rows}]")
+                flag += f"[num_rows$eq{self.num_rows}]"
+            flags.append(flag)
 
         return f'criteria={",".join(flags)}'
 

--- a/src/atldld/requests.py
+++ b/src/atldld/requests.py
@@ -1,0 +1,138 @@
+"""REST API requests to the AIBS servers.
+
+More info: https://help.brain-map.org/display/api/Allen+Brain+Atlas+API
+"""
+import logging
+from dataclasses import dataclass, replace
+from typing import Any, Dict, Optional, Sequence, Tuple
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_API_BASE_URL = "https://api.brain-map.org/api/v2"
+
+
+class RMAError(Exception):
+    """Raised when the RMA response status is False."""
+
+
+@dataclass
+class RMAParameters:
+    """Abstraction of RMA parameters."""
+
+    model: str
+    criteria: Optional[Dict[str, Any]] = None
+    include: Optional[Sequence[str]] = None
+    start_row: Optional[int] = None
+    num_rows: Optional[int] = None
+
+    def __str__(self) -> str:
+        """Convert RMA parameters to URL parameters."""
+        flags = [f"model::{self.model}"]
+
+        # Criteria
+        if self.criteria is not None:
+            flags.append("rma::criteria")
+            flags.append("".join(f"[{k}$eq{v}]" for k, v in self.criteria.items()))
+
+        # Include
+        if self.include is not None:
+            flags.append("rma::include")
+            flags.extend(self.include)
+
+        # Options
+        flags.append("rma::options")
+        if self.start_row is not None:
+            flags.append(f"[start_row$eq{self.start_row}]")
+        if self.num_rows is not None:
+            flags.append(f"[num_rows$eq{self.num_rows}]")
+
+        return f'criteria={",".join(flags)}'
+
+
+def rma_all(rma_parameters: RMAParameters) -> list:
+    """Send one or multiple RMA requests to get all data for given parameters.
+
+    Parameters
+    ----------
+    rma_parameters
+        The RMA query parameters. Corresponds to the part of the query URL
+        that follows the "?" character. The fields start_row and num_rows
+        must be equal to None because they are used/changed in this function
+
+    Returns
+    -------
+    msg : list
+        The data received from the server.
+    """
+    # Make a copy of the parameters (since we'll modify them) and at the same
+    # time set start_row and num_row. The value of 25k rows per request is
+    # the max on the AIBS side.
+    rma_parameters = replace(rma_parameters, start_row=0, num_rows=25000)
+
+    # Initial request. Chances are we already get all the data from it
+    status, msg = rma(rma_parameters)
+    start_row = status["start_row"]
+    num_rows = status["num_rows"]
+    total_rows = status["total_rows"]
+
+    # We didn't specify any value for start_row in the initial request above, so
+    # it should be set to 0 by default.
+    if start_row != 0:
+        raise RuntimeError(f"Expected start_row to be 0 but got {start_row}")
+
+    # If not all data was received on the initial request, then send further
+    # requests to get the remaining items
+    pos = num_rows
+    while pos < total_rows:
+        rma_parameters.start_row = pos
+        status, new_msg = rma(rma_parameters)
+
+        # Check if the reported total_rows is consistent with initial response
+        if status["total_rows"] != total_rows:
+            raise RuntimeError(
+                f'Expected total_rows to be {total_rows} but got {status["total_rows"]}'
+            )
+
+        # Each new request should yield new data. If no data was received, then
+        # something must have gone wrong.
+        if status["num_rows"] == 0:
+            raise RuntimeError("No data received")
+
+        pos += status["num_rows"]
+        msg += new_msg
+
+    return msg
+
+
+def rma(rma_parameters: RMAParameters) -> Tuple[dict, list]:
+    """Send a single RMA query and separate status and data from the response.
+
+    Parameters
+    ----------
+    rma_parameters
+        The RMA query parameters. Corresponds to the part of the query URL
+        that follows the "?" character.
+
+    Returns
+    -------
+    status : dict
+        The response status. Has keys "success", "id", "start_row", "num_rows",
+        "total_rows".
+    msg : list
+        The requested data.
+    """
+    url = f"{_API_BASE_URL}/data/query.json?{rma_parameters}"
+    response = requests.get(url)
+    response.raise_for_status()
+
+    status = response.json()
+    msg = status.pop("msg")
+    logger.debug("Total rows: %d", status["total_rows"])
+
+    # If success = False then msg is a string with the error description
+    if not status["success"]:
+        raise RMAError(f"{msg}\nURL: {url}")
+
+    return status, msg

--- a/src/atldld/requests.py
+++ b/src/atldld/requests.py
@@ -1,3 +1,19 @@
+# The package atldld is a tool to download atlas data.
+#
+# Copyright (C) 2021 EPFL/Blue Brain Project
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """REST API requests to the AIBS servers.
 
 More info: https://help.brain-map.org/display/api/Allen+Brain+Atlas+API

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,29 @@
+from atldld.dataset import PlaneOfSection, ReferenceSpace
+
+
+class TestPlaneOfSection:
+    def test_members(self):
+        assert "CORONAL" in PlaneOfSection.__members__
+        assert "SAGITTAL" in PlaneOfSection.__members__
+
+    def test_values(self):
+        assert PlaneOfSection.CORONAL.value == 1
+        assert PlaneOfSection.SAGITTAL.value == 2
+
+    def test_str(self):
+        assert str(PlaneOfSection.CORONAL) == "coronal"
+        assert str(PlaneOfSection.SAGITTAL) == "sagittal"
+
+
+class TestReferenceSpace:
+    def test_members(self):
+        assert "P56" in ReferenceSpace.__members__
+        assert "P56_LR_FLIPPED" in ReferenceSpace.__members__
+
+    def test_values(self):
+        assert ReferenceSpace.P56.value == 9
+        assert ReferenceSpace.P56_LR_FLIPPED.value == 10
+
+    def test_str(self):
+        assert str(ReferenceSpace.P56) == "P56 Brain"
+        assert str(ReferenceSpace.P56_LR_FLIPPED) == "P56 Brain, L/R Flipped"

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,3 +1,19 @@
+# The package atldld is a tool to download atlas data.
+#
+# Copyright (C) 2021 EPFL/Blue Brain Project
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from atldld.dataset import PlaneOfSection, ReferenceSpace
 
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1,3 +1,19 @@
+# The package atldld is a tool to download atlas data.
+#
+# Copyright (C) 2021 EPFL/Blue Brain Project
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import pytest
 
 from atldld.requests import RMAParameters

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1,0 +1,34 @@
+import pytest
+
+from atldld.requests import RMAParameters
+
+
+class TestRMAParameters:
+
+    def test_model(self):
+        params = RMAParameters("my-model")
+        assert str(params) == "criteria=model::my-model"
+
+    def test_criteria(self):
+        criteria = {"id": 10, "name": "dataset"}
+        params = RMAParameters("my-model", criteria=criteria)
+        url_params = "criteria=model::my-model,rma::criteria,[id$eq10][name$eqdataset]"
+        assert str(params) == url_params
+
+    def test_include(self):
+        params = RMAParameters("my-model", include=("genes", "section_images"))
+        url_params = "criteria=model::my-model,rma::include,genes,section_images"
+        assert str(params) == url_params
+
+    @pytest.mark.parametrize(
+        ("start_row", "num_rows", "expected_url_part"),
+        (
+            (5, 20, "[start_row$eq5][num_rows$eq20]"),
+            (5, None, "[start_row$eq5]"),
+            (None, 20, "[num_rows$eq20]"),
+        )
+    )
+    def test_options(self, start_row, num_rows, expected_url_part):
+        params = RMAParameters("my-model", start_row=start_row, num_rows=num_rows)
+        url_params = f"criteria=model::my-model,rma::options{expected_url_part}"
+        assert str(params) == url_params


### PR DESCRIPTION
This is part of my ongoing dev-to-prod code migration.

I'm very open to changes for all new code, so comments are more than welcome.

Also not everything is being tested yet, so more tests will need to be added.

The main idea of this PR is to add the `atldld.requests` module that abstracts the AIBS RMA queries. With this module one should never have to work with bare URLs any more.

I think there is some overlap in functionality with existing code, so like I said, open to discussion.

There are two main functions that were added:
* `rma(rma_parameters) -> status, msg`: send one single RMA request, split off status and content (=msg) and return
* `rma_all(rma_parameters) -> msg`: some requests can yield many items (e.g. section images, datasets, etc.), by default AIBS returns 50 results at most. This function makes sure it collects all results and returns them.

As a demonstration I added a CLI entrypoint: `atldld dataset info DATASET_ID`, try testing with the following:
* `atldld dataset info 479`
* `atldld dataset info 75492803`
* `atldld dataset info 100142355`

Let me know what you think!