### PR TITLE
Add the atldld.__main__ module

### DIFF
--- a/src/atldld/__main__.py
+++ b/src/atldld/__main__.py
@@ -1,0 +1,29 @@
+# The package atldld is a tool to download atlas data.
+#
+# Copyright (C) 2021 EPFL/Blue Brain Project
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""The main CLI entry point.
+
+This module enables running the CLI by running `atldld` as a module:
+
+    $ python -m atldld
+
+This way it is also possible to debug the CLI using the PDB debugger:
+
+    $ python -m pdb -m atldld
+"""
+from atldld.cli import root
+
+root()


### PR DESCRIPTION
This module enables running the CLI by running `atldld` as a module:

```bash
$ python -m atldld
```

This way it is also possible to debug the CLI using the PDB debugger:

```bash
$ python -m pdb -m atldld
```