### PR TITLE
Ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ htmlcov/
 
 # Sphinx documentation
 docs/_build/
+
+# Build artifacts
+/build/
+/dist/


### PR DESCRIPTION
Added `/build/` and `/dist/` to `.gitignore`.

The are used by `python setup.py sdist bdist_wheel` and other build tools. Ignoring them to make sure they're never commited by accident and to not have to delete them by hand every time.