### PR TITLE
Customizable cache folder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+appdirs==1.4.4
 certifi==2021.5.30
 charset-normalizer==2.0.4
 click==8.0.1

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ from setuptools import find_packages, setup
 python_requires = ">=3.6"
 install_requires = [
     "Pillow",
+    "appdirs",
     "click",
     "dataclasses; python_version < '3.7'",
     "matplotlib",

--- a/src/atldld/cli.py
+++ b/src/atldld/cli.py
@@ -58,6 +58,7 @@ def version():
 def cache_dir():
     """Print the location of the global cache directory."""
     import os
+
     from atldld.constants import user_cache_dir
 
     if "XDG_CACHE_HOME" in os.environ:

--- a/src/atldld/cli.py
+++ b/src/atldld/cli.py
@@ -59,7 +59,7 @@ def cache_dir():
     """Print the location of the global cache directory."""
     import os
 
-    from atldld.constants import user_cache_dir
+    from atldld.config import user_cache_dir
 
     if "XDG_CACHE_HOME" in os.environ:
         suffix = " (configured via XDG_CACHE_HOME)"

--- a/src/atldld/cli.py
+++ b/src/atldld/cli.py
@@ -57,9 +57,14 @@ def version():
 )
 def cache_dir():
     """Print the location of the global cache directory."""
+    import os
     from atldld.constants import user_cache_dir
 
-    click.secho("The atldld cache directory is:", fg="green")
+    if "XDG_CACHE_HOME" in os.environ:
+        suffix = " (configured via XDG_CACHE_HOME)"
+    else:
+        suffix = ""
+    click.secho(f"Location of the atldld cache{suffix}:", fg="green")
     click.echo(str(user_cache_dir(create=False).resolve().as_uri()))
 
 

--- a/src/atldld/cli.py
+++ b/src/atldld/cli.py
@@ -45,18 +45,26 @@ def version():
     click.echo(f"Atlas-Download-Tools version {atldld.__version__}")
 
 
-@click.command(help="Location of the global cache folder.")
-def cache_folder():
-    """Print the location of the global cache folder."""
+@click.command(
+    help="""
+    Location of the atldld cache directory.
+
+    By default it is configured as a subdirectory of the OS-specific cache
+    directory. If the XDG_CACHE_HOME environment variable is set its value will
+    override the OS-specific cache directory.
+    """,
+)
+def cache_dir():
+    """Print the location of the global cache directory."""
     from atldld.constants import user_cache_dir
 
-    click.echo("Location of the global cache folder:")
-    click.echo(str(user_cache_dir().resolve()))
+    click.echo("The atldld cache directory is:")
+    click.echo(str(user_cache_dir(create=False).resolve().as_uri()))
 
 
 root.add_command(info)
 info.add_command(version)
-info.add_command(cache_folder)
+info.add_command(cache_dir)
 
 
 # ============================= Dataset subcommand =============================

--- a/src/atldld/cli.py
+++ b/src/atldld/cli.py
@@ -46,6 +46,7 @@ def version():
 
 
 @click.command(
+    name="cache",
     help="""
     Location of the atldld cache directory.
 
@@ -58,7 +59,7 @@ def cache_dir():
     """Print the location of the global cache directory."""
     from atldld.constants import user_cache_dir
 
-    click.echo("The atldld cache directory is:")
+    click.secho("The atldld cache directory is:", fg="green")
     click.echo(str(user_cache_dir(create=False).resolve().as_uri()))
 
 

--- a/src/atldld/cli.py
+++ b/src/atldld/cli.py
@@ -48,10 +48,10 @@ def version():
 @click.command(help="Location of the global cache folder.")
 def cache_folder():
     """Print the location of the global cache folder."""
-    from atldld.constants import GLOBAL_CACHE_FOLDER
+    from atldld.constants import user_cache_dir
 
     click.echo("Location of the global cache folder:")
-    click.echo(str(GLOBAL_CACHE_FOLDER.resolve()))
+    click.echo(str(user_cache_dir().resolve()))
 
 
 root.add_command(info)

--- a/src/atldld/config.py
+++ b/src/atldld/config.py
@@ -1,0 +1,47 @@
+# The package atldld is a tool to download atlas data.
+#
+# Copyright (C) 2021 EPFL/Blue Brain Project
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Configuration of the atldld CLI app and library."""
+import os
+import pathlib
+
+import appdirs
+
+
+def user_cache_dir(create: bool = True) -> pathlib.Path:
+    """Determine currently configured cache directory for atldld.
+
+    Parameters
+    ----------
+    create
+        If true the returned directory will be guaranteed to exist.
+
+    Returns
+    -------
+    pathlib.Path
+        The currently configured cache directory for atldld.
+    """
+    app_name = "atldld"
+    if "XDG_CACHE_HOME" in os.environ:
+        # appdirs reads XDG_CACHE_HOME only on Linux. Make it work for macOS too
+        cache_dir = pathlib.Path(os.environ["XDG_CACHE_HOME"]) / app_name
+    else:
+        cache_dir = pathlib.Path(appdirs.user_cache_dir(app_name))
+    cache_dir = cache_dir.resolve()
+    if create:
+        cache_dir.mkdir(exist_ok=True, parents=True)
+
+    return cache_dir

--- a/src/atldld/constants.py
+++ b/src/atldld/constants.py
@@ -21,7 +21,6 @@ import pathlib
 import appdirs
 
 
-# Set the cache folder
 def user_cache_dir(create: bool = True) -> pathlib.Path:
     """Determine currently configured cache directory for atldld.
 

--- a/src/atldld/constants.py
+++ b/src/atldld/constants.py
@@ -15,33 +15,3 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Various constants."""
-import os
-import pathlib
-
-import appdirs
-
-
-def user_cache_dir(create: bool = True) -> pathlib.Path:
-    """Determine currently configured cache directory for atldld.
-
-    Parameters
-    ----------
-    create
-        If true the returned directory will be guaranteed to exist.
-
-    Returns
-    -------
-    pathlib.Path
-        The currently configured cache directory for atldld.
-    """
-    app_name = "atldld"
-    if "XDG_CACHE_HOME" in os.environ:
-        # appdirs reads XDG_CACHE_HOME only on Linux. Make it work for macOS too
-        cache_dir = pathlib.Path(os.environ["XDG_CACHE_HOME"]) / app_name
-    else:
-        cache_dir = pathlib.Path(appdirs.user_cache_dir(app_name))
-    cache_dir = cache_dir.resolve()
-    if create:
-        cache_dir.mkdir(exist_ok=True, parents=True)
-
-    return cache_dir

--- a/src/atldld/constants.py
+++ b/src/atldld/constants.py
@@ -19,11 +19,16 @@ import appdirs
 import os
 import pathlib
 
+
 # Set the cache folder
-if "XDG_CACHE_HOME" in os.environ:
-    # appdirs reads XDG_CACHE_HOME only on Linux. Make it work for macOS
-    GLOBAL_CACHE_FOLDER = pathlib.Path(os.getenv("XDG_CACHE_HOME")) / "atldld"
-else:
-    GLOBAL_CACHE_FOLDER = pathlib.Path(appdirs.user_cache_dir("atldld"))
-GLOBAL_CACHE_FOLDER = GLOBAL_CACHE_FOLDER.resolve()
-GLOBAL_CACHE_FOLDER.mkdir(exist_ok=True, parents=True)
+def user_cache_dir(create: bool = True) -> pathlib.Path:
+    if "XDG_CACHE_HOME" in os.environ:
+        # appdirs reads XDG_CACHE_HOME only on Linux. Make it work for macOS too
+        cache_dir = pathlib.Path(os.getenv("XDG_CACHE_HOME")) / "atldld"
+    else:
+        cache_dir = pathlib.Path(appdirs.user_cache_dir("atldld"))
+    cache_dir = cache_dir.resolve()
+    if create:
+        cache_dir.mkdir(exist_ok=True, parents=True)
+
+    return cache_dir

--- a/src/atldld/constants.py
+++ b/src/atldld/constants.py
@@ -15,7 +15,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Various constants."""
+import appdirs
+import os
 import pathlib
 
-GLOBAL_CACHE_FOLDER = pathlib.Path.home() / ".atldld"
-GLOBAL_CACHE_FOLDER.mkdir(exist_ok=True)
+# Set the cache folder
+if "XDG_CACHE_HOME" in os.environ:
+    # appdirs reads XDG_CACHE_HOME only on Linux. Make it work for macOS
+    GLOBAL_CACHE_FOLDER = pathlib.Path(os.getenv("XDG_CACHE_HOME")) / "atldld"
+else:
+    GLOBAL_CACHE_FOLDER = pathlib.Path(appdirs.user_cache_dir("atldld"))
+GLOBAL_CACHE_FOLDER = GLOBAL_CACHE_FOLDER.resolve()
+GLOBAL_CACHE_FOLDER.mkdir(exist_ok=True, parents=True)

--- a/src/atldld/constants.py
+++ b/src/atldld/constants.py
@@ -15,18 +15,32 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Various constants."""
-import appdirs
 import os
 import pathlib
+
+import appdirs
 
 
 # Set the cache folder
 def user_cache_dir(create: bool = True) -> pathlib.Path:
+    """Determine currently configured cache directory for atldld.
+
+    Parameters
+    ----------
+    create
+        If true the returned directory will be guaranteed to exist.
+
+    Returns
+    -------
+    pathlib.Path
+        The currently configured cache directory for atldld.
+    """
+    app_name = "atldld"
     if "XDG_CACHE_HOME" in os.environ:
         # appdirs reads XDG_CACHE_HOME only on Linux. Make it work for macOS too
-        cache_dir = pathlib.Path(os.getenv("XDG_CACHE_HOME")) / "atldld"
+        cache_dir = pathlib.Path(os.environ["XDG_CACHE_HOME"]) / app_name
     else:
-        cache_dir = pathlib.Path(appdirs.user_cache_dir("atldld"))
+        cache_dir = pathlib.Path(appdirs.user_cache_dir(app_name))
     cache_dir = cache_dir.resolve()
     if create:
         cache_dir.mkdir(exist_ok=True, parents=True)

--- a/src/atldld/utils.py
+++ b/src/atldld/utils.py
@@ -30,7 +30,7 @@ import numpy as np
 import requests
 from PIL import Image
 
-from atldld.constants import user_cache_dir
+from atldld.config import user_cache_dir
 
 
 def abi_get_request(url):

--- a/src/atldld/utils.py
+++ b/src/atldld/utils.py
@@ -30,7 +30,7 @@ import numpy as np
 import requests
 from PIL import Image
 
-from atldld.constants import GLOBAL_CACHE_FOLDER
+from atldld.constants import user_cache_dir
 
 
 def abi_get_request(url):
@@ -78,7 +78,7 @@ def get_image(
         Integer representing an id of the section image.
     folder
         Local folder where image saved. If None then automatically defaults
-        to `GLOBAL_CACHE_FOLDER`.
+        to the configured cache directory.
     expression
         If True, retrieve the specified expression mask image. Otherwise,
         retrieve the specified image. See references for details.
@@ -102,7 +102,7 @@ def get_image(
     en/latest/allensdk.api.queries.image_download_api.html#allensdk.api.
     queries.image_download_api.ImageDownloadApi>`_
     """
-    folder = folder or GLOBAL_CACHE_FOLDER
+    folder = folder or user_cache_dir()
     folder = pathlib.Path(folder)
     folder.mkdir(exist_ok=True, parents=True)
 

--- a/src/atldld/utils.py
+++ b/src/atldld/utils.py
@@ -102,9 +102,7 @@ def get_image(
     en/latest/allensdk.api.queries.image_download_api.html#allensdk.api.
     queries.image_download_api.ImageDownloadApi>`_
     """
-    folder = folder or user_cache_dir()
-    folder = pathlib.Path(folder)
-    folder.mkdir(exist_ok=True, parents=True)
+    folder = pathlib.Path(folder or user_cache_dir())
 
     # Construct the image file name and the full path
     file_name = f"{image_id}-{downsample}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,8 @@ PIR_TO_XY_RESPONSES = sorted(PIR_TO_XY_FOLDER.iterdir())
 
 @pytest.fixture(autouse=True)
 def custom_cache_dir(monkeypatch, tmpdir):
+    # Automatically use a custom cache directory for all tests to avoid writing
+    # cache data to the user's real cache.
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmpdir))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,11 @@ PIR_TO_XY_FOLDER = DATA_FOLDER / "sync" / "pir_to_xy"
 PIR_TO_XY_RESPONSES = sorted(PIR_TO_XY_FOLDER.iterdir())
 
 
+@pytest.fixture(autouse=True)
+def custom_cache_folder(monkeypatch, tmpdir):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmpdir))
+
+
 @pytest.fixture(scope="function")
 def img_dummy():
     """Generate a dummy image made out of all zeros."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ PIR_TO_XY_RESPONSES = sorted(PIR_TO_XY_FOLDER.iterdir())
 
 
 @pytest.fixture(autouse=True)
-def custom_cache_folder(monkeypatch, tmpdir):
+def custom_cache_dir(monkeypatch, tmpdir):
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmpdir))
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,11 +42,11 @@ class TestInfoSubgroup:
         assert result.exit_code == 0
         assert atldld.__version__ in result.output
 
-    def test_cache_folder_command_works(self):
+    def test_cache_dir_command_works(self):
         runner = CliRunner()
-        result = runner.invoke(info, ["cache-folder"])
+        result = runner.invoke(info, ["cache-dir"])
         assert result.exit_code == 0
-        assert "global cache folder" in result.output.lower()
+        assert "atldld cache directory" in result.output.lower()
 
 
 class TestDatasetSubgroup:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,7 +46,21 @@ class TestInfoSubgroup:
         runner = CliRunner()
         result = runner.invoke(info, ["cache"])
         assert result.exit_code == 0
-        assert "atldld cache directory" in result.output.lower()
+        assert "atldld cache" in result.output.lower()
+
+    def test_cache_command_shows_xdg(self, monkeypatch, tmpdir):
+        runner = CliRunner()
+
+        monkeypatch.delenv("XDG_CACHE_HOME")
+        result = runner.invoke(info, ["cache"])
+        assert result.exit_code == 0
+        assert "XDG_CACHE_HOME" not in result.output
+
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmpdir))
+        result = runner.invoke(info, ["cache"])
+        assert result.exit_code == 0
+        assert "XDG_CACHE_HOME" in result.output
+
 
 
 class TestDatasetSubgroup:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,9 +42,9 @@ class TestInfoSubgroup:
         assert result.exit_code == 0
         assert atldld.__version__ in result.output
 
-    def test_cache_dir_command_works(self):
+    def test_cache_command_works(self):
         runner = CliRunner()
-        result = runner.invoke(info, ["cache-dir"])
+        result = runner.invoke(info, ["cache"])
         assert result.exit_code == 0
         assert "atldld cache directory" in result.output.lower()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,7 +62,6 @@ class TestInfoSubgroup:
         assert "XDG_CACHE_HOME" in result.output
 
 
-
 class TestDatasetSubgroup:
     def test_running_without_arguments_prints_help(self):
         runner = CliRunner()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,44 @@
+# The package atldld is a tool to download atlas data.
+#
+# Copyright (C) 2021 EPFL/Blue Brain Project
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import pathlib
+
+import pytest
+
+from atldld.config import user_cache_dir
+
+
+class TestUserCacheDir:
+    def test_default_cache_dir_works(self):
+        cache_dir = user_cache_dir()
+        assert cache_dir.exists()
+        assert cache_dir.is_dir()
+
+    def test_default_cache_in_user_home(self, monkeypatch):
+        # All tests use a custom cache directory set by the custom_cache_dir
+        # fixture in conftest. Unset this just for this test.
+        monkeypatch.delenv("XDG_CACHE_HOME")
+        cache_dir = user_cache_dir(create=False)
+        assert pathlib.Path.home() in cache_dir.parents
+
+    @pytest.mark.parametrize("create", [True, False])
+    def test_custom_cache_dir_works(self, monkeypatch, tmpdir, create):
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmpdir))
+        cache_dir = user_cache_dir(create=create)
+        assert cache_dir == pathlib.Path(tmpdir) / "atldld"
+        if create:
+            assert cache_dir.exists()
+            assert cache_dir.is_dir()

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -14,9 +14,31 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-from atldld.constants import GLOBAL_CACHE_FOLDER
+import pathlib
+
+import pytest
+
+from atldld.constants import user_cache_dir
 
 
-def test_global_cache_folder():
-    assert GLOBAL_CACHE_FOLDER.exists()
-    assert GLOBAL_CACHE_FOLDER.is_dir()
+class TestUserCacheDir:
+    def test_default_cache_folder_works(self):
+        cache_dir = user_cache_dir()
+        assert cache_dir.exists()
+        assert cache_dir.is_dir()
+
+    def test_default_cache_in_user_home(self, monkeypatch):
+        # All tests use a custom cache folder set by the custom_cache_folder
+        # fixture in conftest. Unset this just for this test.
+        monkeypatch.delenv("XDG_CACHE_HOME")
+        cache_dir = user_cache_dir(create=False)
+        assert pathlib.Path.home() in cache_dir.parents
+
+    @pytest.mark.parametrize("create", [True, False])
+    def test_custom_cache_folder_works(self, monkeypatch, tmpdir, create):
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmpdir))
+        cache_dir = user_cache_dir(create=create)
+        assert cache_dir == pathlib.Path(tmpdir) / "atldld"
+        if create:
+            assert cache_dir.exists()
+            assert cache_dir.is_dir()

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -14,31 +14,3 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import pathlib
-
-import pytest
-
-from atldld.constants import user_cache_dir
-
-
-class TestUserCacheDir:
-    def test_default_cache_dir_works(self):
-        cache_dir = user_cache_dir()
-        assert cache_dir.exists()
-        assert cache_dir.is_dir()
-
-    def test_default_cache_in_user_home(self, monkeypatch):
-        # All tests use a custom cache directory set by the custom_cache_dir
-        # fixture in conftest. Unset this just for this test.
-        monkeypatch.delenv("XDG_CACHE_HOME")
-        cache_dir = user_cache_dir(create=False)
-        assert pathlib.Path.home() in cache_dir.parents
-
-    @pytest.mark.parametrize("create", [True, False])
-    def test_custom_cache_dir_works(self, monkeypatch, tmpdir, create):
-        monkeypatch.setenv("XDG_CACHE_HOME", str(tmpdir))
-        cache_dir = user_cache_dir(create=create)
-        assert cache_dir == pathlib.Path(tmpdir) / "atldld"
-        if create:
-            assert cache_dir.exists()
-            assert cache_dir.is_dir()

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -22,20 +22,20 @@ from atldld.constants import user_cache_dir
 
 
 class TestUserCacheDir:
-    def test_default_cache_folder_works(self):
+    def test_default_cache_dir_works(self):
         cache_dir = user_cache_dir()
         assert cache_dir.exists()
         assert cache_dir.is_dir()
 
     def test_default_cache_in_user_home(self, monkeypatch):
-        # All tests use a custom cache folder set by the custom_cache_folder
+        # All tests use a custom cache directory set by the custom_cache_dir
         # fixture in conftest. Unset this just for this test.
         monkeypatch.delenv("XDG_CACHE_HOME")
         cache_dir = user_cache_dir(create=False)
         assert pathlib.Path.home() in cache_dir.parents
 
     @pytest.mark.parametrize("create", [True, False])
-    def test_custom_cache_folder_works(self, monkeypatch, tmpdir, create):
+    def test_custom_cache_dir_works(self, monkeypatch, tmpdir, create):
         monkeypatch.setenv("XDG_CACHE_HOME", str(tmpdir))
         cache_dir = user_cache_dir(create=create)
         assert cache_dir == pathlib.Path(tmpdir) / "atldld"


### PR DESCRIPTION
Closes #7

* Use `appdirs` to determine the cache folder location
* Respect the `XDG_CACHE_HOME` environment variable
* Dynamically determine the cache directory instead of at import time
* Use a custom cache directory for all tests