### PR TITLE
Cache responses of xy_to_pir_API_single

### DIFF
--- a/src/atldld/utils.py
+++ b/src/atldld/utils.py
@@ -25,7 +25,7 @@ operation.
 import json
 import pathlib
 import warnings
-from typing import Dict, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import requests
@@ -527,9 +527,9 @@ def xy_to_pir_API_single(
     """
     xy_param = f"x={x}&y={y}"
 
-    # Load the cache file or create it if it doesn't exist
+    # Load the cache file or create it if it doesn't exist.
+    # The format of the cache is {"x=x_val&y=y_val": [p, i, r]}.
     cache_file = user_cache_dir() / "image-to-reference" / f"{image_id}.json"
-    cached_points: Dict[str, Tuple[float, float, float]]
     if cache_file.exists():
         with cache_file.open() as fp:
             cached_points = json.load(fp)
@@ -553,7 +553,14 @@ def xy_to_pir_API_single(
         with cache_file.open("w") as fp:
             json.dump(cached_points, fp)
 
-    return cached_points[xy_param]
+    # Constructing a tuple explicitly because json.load produces lists of
+    # arbitrary lengths, not tuples of length 3
+    pir = (
+        cached_points[xy_param][0],
+        cached_points[xy_param][1],
+        cached_points[xy_param][2],
+    )
+    return pir
 
 
 class CommonQueries:

--- a/src/atldld/utils.py
+++ b/src/atldld/utils.py
@@ -528,7 +528,7 @@ def xy_to_pir_API_single(
     xy_param = f"x={x}&y={y}"
 
     # Load the cache file or create it if it doesn't exist
-    cache_file = GLOBAL_CACHE_FOLDER / "image-to-reference" / f"{image_id}.json"
+    cache_file = user_cache_dir() / "image-to-reference" / f"{image_id}.json"
     cached_points: Dict[str, Tuple[float, float, float]]
     if cache_file.exists():
         with cache_file.open() as fp:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -117,6 +117,44 @@ def test_get_corners_in_ref_space(mocker):
     )
 
 
+class TestXyToPirApiSingle:
+    @pytest.mark.parametrize("image_id", EXISTING_IMAGE_IDS[:1])
+    @pytest.mark.parametrize("x", [10])
+    @pytest.mark.parametrize("y", [40])
+    def test_xy_to_pir_API_single(self, image_id, x, y, mocker):
+        """Test that xy to pir API works."""
+
+        # patching
+        fake_response = Mock(spec=requests.Request)
+        fake_response.ok = True
+
+        rv = {
+            "success": True,
+            "id": 0,
+            "start_row": 0,
+            "num_rows": 0,
+            "total_rows": 0,
+            "msg": {
+                "image_to_reference": {
+                    "x": -983.5501122512056,
+                    "y": 335.1538167934086,
+                    "z": 4117.19706627407,
+                }
+            },
+        }
+
+        fake_response.json = Mock(return_value=rv)
+        mocker.patch("requests.get", return_value=fake_response)
+
+        p, i, r = xy_to_pir_API_single(x, y, image_id=image_id)
+
+        # Mock calls
+        fake_response.assert_called_once()
+        assert np.isfinite(p)
+        assert np.isfinite(i)
+        assert np.isfinite(r)
+
+
 class TestUtils:
     @pytest.mark.internet
     def test_get_experiment_list(self):
@@ -490,44 +528,6 @@ class TestUtils:
         assert np.isfinite(closest_section_image_id)
         assert isinstance(closest_section_image_id, int)
 
-    @pytest.mark.parametrize("image_id", EXISTING_IMAGE_IDS[:1])
-    @pytest.mark.parametrize("x", [10])
-    @pytest.mark.parametrize("y", [40])
-    def test_xy_to_pir_API_single(self, image_id, x, y, mocker):
-        """Test that xy to pir API works."""
-
-        # patching
-        fake_response = Mock(spec=requests.Request)
-        fake_response.ok = True
-
-        rv = {
-            "success": True,
-            "id": 0,
-            "start_row": 0,
-            "num_rows": 0,
-            "total_rows": 0,
-            "msg": {
-                "image_to_reference": {
-                    "x": -983.5501122512056,
-                    "y": 335.1538167934086,
-                    "z": 4117.19706627407,
-                }
-            },
-        }
-
-        fake_response.json = Mock(return_value=rv)
-        mocker.patch("requests.get", return_value=fake_response)
-
-        p, i, r = xy_to_pir_API_single(x, y, image_id=image_id)
-
-        # Mock calls
-        assert (
-            fake_response.json.call_count == 1
-        )  # assert_called not available in python 3.5 :(
-
-        assert np.isfinite(p)
-        assert np.isfinite(i)
-        assert np.isfinite(r)
 
     @pytest.mark.internet
     @pytest.mark.parametrize("dataset_id", EXISTING_DATASET_IDS)


### PR DESCRIPTION
This is currently the bottleneck when running `atldld dataset preview` and `atldld dataset download-faithful` with the same parameters again and again. This is because for every section image the four corners in ref space have to be queried.

Testing: run `atldld dataset preview {479, 75492803, ...}` multiple times.