### PR TITLE
Fix Description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,11 +48,13 @@ extras_require = {
 }
 
 description = "Search, download, and prepare atlas data."
-long_description = """ Among different sources of data, Allen Brain Institute
+long_description = """
+Among different sources of data, Allen Brain Institute
 hosts a rich database of gene expression images, Nissl volumes, and annotation atlases.
 The Atlas-Download-Tools library can help you to download single section images
 and entire datasets, as well as the corresponding metadata. It can further
-pre-process the image data to place it in the standard reference space."""
+pre-process the image data to place it in the standard reference space.
+"""
 
 setup(
     name="atldld",
@@ -71,6 +73,7 @@ setup(
     entry_points={"console_scripts": ["atldld = atldld.cli:root"]},
     description=description,
     long_description=long_description,
+    long_description_content_type="text/x-rst",
     license="LGPLv3",
     classifiers=[
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",


### PR DESCRIPTION
Doing the process to release `Atlas Download Tools` on PyPI, 

```
python setup.py sdist bdist_wheel
twine check dist/*
```

I stumbled upon an issue:

```
Checking dist/atldld-0.3.2.dev0-py3-none-any.whl: FAILED
  `long_description` has syntax errors in markup and would not be rendered on PyPI.
    line 2: Warning: Block quote ends without a blank line; unexpected unindent.
Checking dist/atldld-0.3.2.dev0.tar.gz: FAILED
  `long_description` has syntax errors in markup and would not be rendered on PyPI.
    line 2: Warning: Block quote ends without a blank line; unexpected unindent.
```

This PR is fixing it. Sorry about this @Stannislav, @jankrepl !