### PR TITLE
Don't require opencv-python if opencv is already installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ install_requires = [
     "dataclasses; python_version < '3.7'",
     "matplotlib",
     "numpy",
-    "opencv-python",
     "requests",
     "scikit-image",
 ]
@@ -45,6 +44,12 @@ extras_require = {
     ],
     "docs": ["sphinx>=1.3", "sphinx-bluebrain-theme"],
 }
+
+try:
+    # Could already be installed on the system
+    import cv2
+except ImportError:
+    install_requires.append("opencv-python")
 
 description = "Search, download, and prepare atlas data."
 long_description = """

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extras_require = {
 
 try:
     # Could already be installed on the system
-    import cv2
+    import cv2  # noqa
 except ImportError:
     install_requires.append("opencv-python")
 


### PR DESCRIPTION
This will allow us to get rid of py-opencv-python in our Spack deployment